### PR TITLE
Stop exceptions from breaking the watcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     },
     "require": {
         "php": "^7.2",
+        "cweagans/composer-patches": "^1.6",
         "pattern-lab/core": "^2.0",
         "pattern-lab/patternengine-twig": "^2.0",
         "pattern-lab/styleguidekit-twig-default": "^3.0"
@@ -36,5 +37,13 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "composer-exit-on-patch-failure": true,
+        "patches": {
+            "pattern-lab/core": {
+                "Stop exceptions from breaking the watcher": "https://github.com/pattern-lab/patternlab-php-core/pull/170.patch"
+            }
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c46ad4f7ac398814a37eaed8ba4a326",
+    "content-hash": "48dadebf715fd501a66ea3d30f962575",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -67,6 +67,50 @@
                 "zip"
             ],
             "time": "2016-02-15T22:46:40+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "2ec4f00ff5fb64de584c8c4aea53bf9053ecb0b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/2ec4f00ff5fb64de584c8c4aea53bf9053ecb0b3",
+                "reference": "2ec4f00ff5fb64de584c8c4aea53bf9053ecb0b3",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "time": "2018-05-11T18:00:16+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -261,6 +305,11 @@
                 "symfony/yaml": "^3.0"
             },
             "type": "library",
+            "extra": {
+                "patches_applied": {
+                    "Stop exceptions from breaking the watcher": "https://github.com/pattern-lab/patternlab-php-core/pull/170.patch"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "PatternLab": "src/"


### PR DESCRIPTION
Applies https://github.com/pattern-lab/patternlab-php-core/pull/170, which stops invalid Twig templates from breaking the watcher.