### PR TITLE
[WIP] css custom props

### DIFF
--- a/source/css/sass/custom-property-ideas/_color-custom-properties.scss
+++ b/source/css/sass/custom-property-ideas/_color-custom-properties.scss
@@ -1,0 +1,25 @@
+@at-root {
+  :root {
+    --color-primary-normal: rgb(2, 136, 209);
+    --color-primary-light: rgb(179, 229, 252);
+    --color-primary-dark: rgb(2, 119, 189);
+    --color-text-normal: rgb(33, 33, 33);
+    --color-text-reverse: rgb(255, 255, 255);
+    --color-text-secondary: rgb(136, 136, 136);
+    --color-text-secondary__reverse: rgb(158, 158, 158);
+    --color-text-placeholder: rgb(189, 189, 189);
+    --color-text-dividers: rgb(224, 224, 224);
+    --color-text-dividers__reverse: rgb(97, 97, 97);
+    --color-text-ui_background: rgb(255, 255, 255);
+    --color-text-ui_background_hue: rgb(245, 245, 245);
+    --color-text-ui_code: rgb(247, 247, 247);
+    --color-text-ui_background__reverse: rgb(33, 33, 33);
+    --color-text-ui_background_hue__reverse: rgb(51, 51, 51);
+    --color-background: rgb(255, 255, 255);
+    --color-information: rgb(2, 136, 209);
+    --color-success: rgb(98, 159, 67);
+    --color-success_dark: rgb(86, 144, 55);
+    --color-attention: rgb(207, 12, 78);
+    --color-warning: rgb(230, 81, 0);
+  }
+}

--- a/source/css/sass/custom-property-ideas/_color-map.scss
+++ b/source/css/sass/custom-property-ideas/_color-map.scss
@@ -1,0 +1,23 @@
+$colors: (
+  primary-normal: rgb(2, 136, 209),
+  primary-light: rgb(179, 229, 252),
+  primary-dark: rgb(2, 119, 189),
+  text-normal: rgb(33, 33, 33),
+  text-reverse: rgb(255, 255, 255),
+  text-secondary: rgb(136, 136, 136),
+  text-secondary__reverse: rgb(158, 158, 158),
+  text-placeholder: rgb(189, 189, 189),
+  text-dividers: rgb(224, 224, 224),
+  text-dividers__reverse: rgb(97, 97, 97),
+  text-ui_background: rgb(255, 255, 255),
+  text-ui_background_hue: rgb(245, 245, 245),
+  text-ui_code: rgb(247, 247, 247),
+  text-ui_background__reverse: rgb(33, 33, 33),
+  text-ui_background_hue__reverse: rgb(51, 51, 51),
+  background: rgb(255, 255, 255),
+  information: rgb(2, 136, 209),
+  success: rgb(98, 159, 67),
+  success_dark: rgb(86, 144, 55),
+  attention: rgb(207, 12, 78),
+  warning: rgb(230, 81, 0)
+);

--- a/source/css/sass/custom-property-ideas/color.scss
+++ b/source/css/sass/custom-property-ideas/color.scss
@@ -1,0 +1,6 @@
+@import "mixins/color";
+
+body {
+  @include set-colors("warning", "text-ui_background");
+  z-index: 222;
+}

--- a/source/css/sass/custom-property-ideas/mixins/_color.scss
+++ b/source/css/sass/custom-property-ideas/mixins/_color.scss
@@ -16,12 +16,16 @@
   }
 }
 
+@mixin set-css-property-from-color-map($property-name, $color-name) {
+  @include set-css-property-from-map($property-name, $color-name, "color", $colors);
+}
+
 @mixin set-color($color-name) {
-  @include set-css-property-from-map(color, $color-name, "color", $colors);
+  @include set-css-property-from-color-map(color, $color-name);
 }
 
 @mixin set-background-color($color-name) {
-  @include set-css-property-from-map(background-color, $color-name, "color", $colors);
+  @include set-css-property-from-color-map(background-color, $color-name);
 }
 
 @mixin set-colors($color-name, $background-color-name) {

--- a/source/css/sass/custom-property-ideas/mixins/_color.scss
+++ b/source/css/sass/custom-property-ideas/mixins/_color.scss
@@ -12,7 +12,7 @@
 
   }
   @else {
-    @error("Trying to set unknown color name  " + $customPropertyName);
+    @error("Trying to set unknown " + $customPropertyNamePrefix + "  name:  " + $customPropertyName);
   }
 }
 

--- a/source/css/sass/custom-property-ideas/mixins/_color.scss
+++ b/source/css/sass/custom-property-ideas/mixins/_color.scss
@@ -1,0 +1,30 @@
+@import "../color-map";
+
+@mixin set-css-property-from-map($propertyName, $customPropertyNameStem, $customPropertyNamePrefix, $customPropertyMap) {
+  $value: map-get($customPropertyMap, $customPropertyNameStem);
+  @if $value != null {
+    $customPropertyName: unquote(--#{$customPropertyNamePrefix}-#{$customPropertyNameStem});
+    #{$propertyName}: $value;
+
+    @supports( $propertyName: var($customPropertyName) ) {
+      #{$propertyName}: var($customPropertyName);
+    }
+
+  }
+  @else {
+    @error("Trying to set unknown color name  " + $customPropertyName);
+  }
+}
+
+@mixin set-color($color-name) {
+  @include set-css-property-from-map(color, $color-name, "color", $colors);
+}
+
+@mixin set-background-color($color-name) {
+  @include set-css-property-from-map(background-color, $color-name, "color", $colors);
+}
+
+@mixin set-colors($color-name, $background-color-name) {
+  @include set-css-property-from-map(color, $color-name, "color", $colors);
+  @include set-css-property-from-map(background-color, $background-color-name, "color", $colors);
+}

--- a/source/css/sass/custom-property-ideas/mixins/_color.scss
+++ b/source/css/sass/custom-property-ideas/mixins/_color.scss
@@ -25,6 +25,6 @@
 }
 
 @mixin set-colors($color-name, $background-color-name) {
-  @include set-css-property-from-map(color, $color-name, "color", $colors);
-  @include set-css-property-from-map(background-color, $background-color-name, "color", $colors);
+  @include set-color($color-name);
+  @include set-background-color($background-color-name);
 }

--- a/source/css/sass/custom-property-ideas/mixins/_color.scss
+++ b/source/css/sass/custom-property-ideas/mixins/_color.scss
@@ -1,6 +1,7 @@
 @import "../color-map";
 
-@mixin set-css-property-from-map($propertyName, $customPropertyNameStem, $customPropertyNamePrefix, $customPropertyMap) {
+// Move this to non-color-specific file
+@mixin set-from-map($propertyName, $customPropertyNameStem, $customPropertyNamePrefix, $customPropertyMap) {
   $value: map-get($customPropertyMap, $customPropertyNameStem);
   @if $value != null {
     $customPropertyName: unquote(--#{$customPropertyNamePrefix}-#{$customPropertyNameStem});
@@ -16,16 +17,16 @@
   }
 }
 
-@mixin set-css-property-from-color-map($property-name, $color-name) {
-  @include set-css-property-from-map($property-name, $color-name, "color", $colors);
+@mixin set-from-color-map($property-name, $color-name) {
+  @include set-from-map($property-name, $color-name, "color", $colors);
 }
 
 @mixin set-color($color-name) {
-  @include set-css-property-from-color-map(color, $color-name);
+  @include set-from-color-map(color, $color-name);
 }
 
 @mixin set-background-color($color-name) {
-  @include set-css-property-from-color-map(background-color, $color-name);
+  @include set-from-color-map(background-color, $color-name);
 }
 
 @mixin set-colors($color-name, $background-color-name) {


### PR DESCRIPTION
[Exploratory. Not to be merged.]

Experiments show that the sass processor ignores lines that are setting CSS custom properties, which means that we can't simply do something like

```
  --color-primary-normal: $color-primary-normal;  // ignored by sass processor
```

Instead, the config generation process that builds the sass variable files will also need to directly construct the files to set the css custom properties. In this PR, these are the files `_color-map.scss` and `_color-custom-properties.scss`.

Note we've switched to using a map for the sass values as it makes the name management between the sass references and the css custom properties slightly easier.