### PR TITLE
[WIP] Use CLDR data for list separators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@
 /source/css/*.map
 /source/styleguide/
 /vendor/
+/source/css/sass/_locales.scss
 /source/css/sass/variables/
 /source/js/derivedConfig.json

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,6 +2,7 @@
   "ignoreFiles": [
     "./**/!(*.scss)",
     "./export/css/sass/**/*",
+    "./source/css/sass/_locales.scss",
     "./source/css/sass/variables/**/*",
     "./source/css/sass/vendor/**/*"
   ],

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -17,6 +17,7 @@ import sassGlob from 'gulp-sass-glob';
 import sourcemaps from 'gulp-sourcemaps';
 import stylelint from 'stylelint';
 import syntaxScss from 'postcss-scss';
+import tags from 'language-tags';
 
 const buildConfig = (invocationArgs, publicRoot, sourceRoot, testRoot, exportRoot) => {
 
@@ -120,6 +121,7 @@ const generateSassLocaleData = () => {
   const locales = cldr.localeIds.filter(locale => locale !== 'root')
     .concat(Object.keys(cldr.extractLanguageSupplementalMetadata()))
     .map(locale => locale.replace(/_/g, '-').toLowerCase())
+    .filter(locale => tags.check(locale))
     .reduce((localeParents, locale) => {
       while (true) {
         const parent = locale.replace(/-[^-]+$/, '');
@@ -134,10 +136,11 @@ const generateSassLocaleData = () => {
       }
     }, {});
 
+  const aliases = cldr.extractLanguageSupplementalMetadata();
   const listSeparators = ['und'].concat(Object.keys(locales))
     .reduce((carry, locale) =>
       Object.assign(carry,
-        {[locale]: cldr.extractListPatterns(locale).default.middle.replace(/{[0|1]}/g, '')},
+        {[locale]: cldr.extractListPatterns(aliases[locale] ? aliases[locale]['replacement'] : locale).default.middle.replace(/{[0|1]}/g, '')},
       ), {});
 
   const queue = Object.keys(listSeparators).sort().reverse();

--- a/package-lock.json
+++ b/package-lock.json
@@ -5898,6 +5898,21 @@
       "integrity": "sha512-nQRpMcHm1cQ6gmztdvLcIvxocznSMqH/y6XtERrWrHaymOYdDGroRqetJvJycxGEr1aakXiigDgn7JnzuXlk6A==",
       "dev": true
     },
+    "language-subtag-registry": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.18.tgz",
+      "integrity": "sha1-gM/oSN+I97+Ajb2tCyjn+iw1eN0=",
+      "dev": true
+    },
+    "language-tags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
+      "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
+      "dev": true,
+      "requires": {
+        "language-subtag-registry": "~0.3.2"
+      }
+    },
     "last-run": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1969,6 +1969,15 @@
         "check-error": "^1.0.2"
       }
     },
+    "chainsaw": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.0.9.tgz",
+      "integrity": "sha1-EaBRAtHEx4W20EFdM21aOhYSkT4=",
+      "dev": true,
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
+      }
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -2071,6 +2080,24 @@
             "is-descriptor": "^0.1.0"
           }
         }
+      }
+    },
+    "cldr": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/cldr/-/cldr-4.13.0.tgz",
+      "integrity": "sha512-azSL1aMvsZM9Im6ZrnMhW/b3xF02YhoFckB7zzyjDKipUGjbVgkQSGukgJP+kFlEYCxKrCzU4Fj/nCchjjqZcw==",
+      "dev": true,
+      "requires": {
+        "escodegen": "^1.11.0",
+        "esprima": "^4.0.1",
+        "lodash": "^4.17.10",
+        "memoizeasync": "^1.1.0",
+        "passerror": "^1.1.1",
+        "pegjs": "^0.10.0",
+        "seq": "^0.3.5",
+        "unicoderegexp": "^0.4.1",
+        "xmldom": "^0.1.27",
+        "xpath": "^0.0.27"
       }
     },
     "cliui": {
@@ -2510,6 +2537,12 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "deep-iterator": {
       "version": "1.1.0",
@@ -3042,10 +3075,44 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "escodegen": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+      "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+      "dev": true,
+      "requires": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
@@ -3366,6 +3433,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "file-entry-cache": {
@@ -5024,6 +5097,15 @@
         }
       }
     },
+    "hashish": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/hashish/-/hashish-0.0.4.tgz",
+      "integrity": "sha1-bWC8b/r3Ebav1g5CbQd5iAFOZVQ=",
+      "dev": true,
+      "requires": {
+        "traverse": ">=0.2.4"
+      }
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -5885,6 +5967,16 @@
         "flush-write-stream": "^1.0.2"
       }
     },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
     "liftoff": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
@@ -6246,6 +6338,24 @@
       "requires": {
         "unist-util-modify-children": "^1.0.0",
         "unist-util-visit": "^1.1.0"
+      }
+    },
+    "memoizeasync": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memoizeasync/-/memoizeasync-1.1.0.tgz",
+      "integrity": "sha1-nXAopvJm3rczUQu327pfUYeMVh4=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.5.0",
+        "passerror": "1.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+          "integrity": "sha1-2COIrpyWC+y+oMc7uet5tsbOmus=",
+          "dev": true
+        }
       }
     },
     "memoizee": {
@@ -6888,6 +6998,20 @@
         "is-wsl": "^1.1.0"
       }
     },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
     "ordered-read-streams": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
@@ -7095,6 +7219,12 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
+    "passerror": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/passerror/-/passerror-1.1.1.tgz",
+      "integrity": "sha1-oluI292RCilgOux9y5bpp6l2h7Q=",
+      "dev": true
+    },
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -7181,6 +7311,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "pegjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
       "dev": true
     },
     "performance-now": {
@@ -7587,6 +7723,12 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
       "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "preserve": {
@@ -8331,6 +8473,16 @@
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
+      }
+    },
+    "seq": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/seq/-/seq-0.3.5.tgz",
+      "integrity": "sha1-rgKvOkJHk9jMvyEtaRdODFTf/jg=",
+      "dev": true,
+      "requires": {
+        "chainsaw": ">=0.0.7 <0.1",
+        "hashish": ">=0.0.2 <0.1"
       }
     },
     "serve-index": {
@@ -9832,6 +9984,12 @@
         "punycode": "^1.4.1"
       }
     },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "dev": true
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -9885,6 +10043,15 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "type-detect": {
       "version": "4.0.8",
@@ -9975,6 +10142,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
       "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+      "dev": true
+    },
+    "unicoderegexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/unicoderegexp/-/unicoderegexp-0.4.1.tgz",
+      "integrity": "sha1-r7EOTvHu3ccRQXu7ZSvIhdqdQXE=",
       "dev": true
     },
     "unified": {
@@ -10464,6 +10637,12 @@
       "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
       "dev": true
     },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
@@ -10504,10 +10683,22 @@
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
       "dev": true
     },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+      "dev": true
+    },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "dev": true
+    },
+    "xpath": {
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
+      "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp-sass-glob": "^1.0.9",
     "gulp-sourcemaps": "^2.6.4",
     "jexl": "^1.1.4",
+    "language-tags": "^1.0.5",
     "minimist": "^1.2.0",
     "normalize.css": "^8.0.1",
     "postcss-reporter": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "browser-sync": "^2.26.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "cldr": "^4.13.0",
     "color": "^3.1.0",
     "deep-iterator": "^1.1.0",
     "deepmerge": "^2.2.1",

--- a/source/css/sass/patterns/molecules/item-tag-list.scss
+++ b/source/css/sass/patterns/molecules/item-tag-list.scss
@@ -1,3 +1,4 @@
+@import "../../locales";
 @import "../../mixins/typography";
 
 .item-tag-list {
@@ -13,16 +14,16 @@
   display: inline;
   @include label-subject-typography();
 
-  &:after {
-    content: ", ";
-  }
-
-  &:lang(ar):after {
-    content: "، ";
-  }
-
-  &:lang(ja):after {
-    content: "、";
+  @each $locale, $separator in $list-separators {
+    @if $locale == "und" {
+      &:after {
+        content: $separator;
+      }
+    } @else {
+      &:lang(#{$locale}):after {
+        content: $separator;
+      }
+    }
   }
 
   &:last-child:after {


### PR DESCRIPTION
The result of this initial commit is what we want: locale data coming from CLDR where possible. The JS will need tidying up but works.

Picking out the right data is tricky. Locale codes in CLDR are similar to BCP 47 (used by HTML), but a bit different. Inheritance being one: for example `en_DE -> en_150 -> en_001 -> en -> root` in CLDR but `en-DE -> en` in BCP 47, and `sr_Latn -> root` in CLDR but `sr-Latn -> sr` in BCP 47 (CLDR has set rules,  BCP 47 just goes up a level). 

And then there's differences like:
- `zh-cmn-Hans-CN` (Chinese, Mandarin, Simplified script, as used in China)
- `cmn-Hans-CN` (Mandarin Chinese, Simplified script, as used in China)
- `zh-yue-HK` (Chinese, Cantonese, as used in Hong Kong SAR)
- `yue-HK` (Cantonese Chinese, as used in Hong Kong SAR)
- `zh-Hans-CN` (Chinese written using the Simplified script as used in mainland China)

So, this uses the CLDR data to get a list of locales, produces a map of parents based on the BCP 47 rule, then uses the CLDR data to work out the right value for _every_ level. It then works out what's superfluous, which is most of it (eg `en-GB` has the same value as `en` so isn't needed, but `en` is the same as the default value so also isn't).