### PR TITLE
Enable strict_variables in Twig

### DIFF
--- a/config/listeners.json
+++ b/config/listeners.json
@@ -1,3 +1,5 @@
 {
-    "listeners": []
+    "listeners": [
+        "\\PatternLab\\Twig\\StrictVariablesListener"
+    ]
 }

--- a/core/src/PatternLab/Twig/StrictVariablesListener.php
+++ b/core/src/PatternLab/Twig/StrictVariablesListener.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PatternLab\Twig;
+
+use PatternLab\Listener;
+use PatternLab\PatternEngine\Twig\TwigUtil;
+
+final class StrictVariablesListener extends Listener
+{
+    public function __construct()
+    {
+        $this->addListener('twigPatternLoader.customize', 'onTwigPatternLoaderCustomize');
+    }
+
+    public function onTwigPatternLoaderCustomize()
+    {
+        TwigUtil::getInstance()->enableStrictVariables();
+    }
+}

--- a/source/_meta/_00-head.twig
+++ b/source/_meta/_00-head.twig
@@ -1,12 +1,12 @@
 <!doctype html>
 
-<html class="{{ htmlClass }}" lang="{{ lang|default('en') }}" dir="{{ dir|default('ltr') }}">
+<html lang="{{ lang|default('en') }}" dir="{{ dir|default('ltr') }}">
 
 <head>
 
   <meta charset="utf-8">
 
-  <title>{{ title }}</title>
+  <title>{{ title|default('') }}</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
@@ -19,4 +19,4 @@
 
 </head>
 
-<body class="{{ bodyClass }}">
+<body>

--- a/source/_patterns/00-atoms/_text.twig
+++ b/source/_patterns/00-atoms/_text.twig
@@ -1,4 +1,8 @@
-{%- if nodes is iterable -%}
+{%- if nodes is not defined -%}
+
+  {# Do nothing #}
+
+{%- elseif nodes is iterable -%}
 
   {%- for node in nodes -%}
 

--- a/source/_patterns/00-atoms/_text.twig
+++ b/source/_patterns/00-atoms/_text.twig
@@ -1,8 +1,4 @@
-{%- if nodes is not defined -%}
-
-  {# Do nothing #}
-
-{%- elseif nodes is iterable -%}
+{%- if nodes is iterable -%}
 
   {%- for node in nodes -%}
 

--- a/source/_patterns/00-atoms/inline/link/link.twig
+++ b/source/_patterns/00-atoms/inline/link/link.twig
@@ -1,8 +1,8 @@
 {% spaceless %}
 
-  {%- if attributes.href is defined -%}
+  {%- if attributes|default({}).href is defined -%}
     <a {%- include 'atoms-attributes' %}>{%- include 'atoms-text' with {nodes: text} only -%}</a>
-  {%- elseif attributes|length -%}
+  {%- elseif attributes|default({})|length -%}
     <span {%- include 'atoms-attributes' %}>{%- include 'atoms-text' with {nodes: text} only -%}</span>
   {%- else -%}
     {%- include 'atoms-text' with {nodes: text} only -%}

--- a/source/_patterns/00-atoms/text.yaml
+++ b/source/_patterns/00-atoms/text.yaml
@@ -1,0 +1,1 @@
+nodes: 'Fake value'

--- a/source/_patterns/01-molecules/tag-list/tag-list.twig
+++ b/source/_patterns/01-molecules/tag-list/tag-list.twig
@@ -5,7 +5,7 @@
   {%- with title|default({}) only -%}
     {%- block title -%}
 
-      {% if text %}
+      {% if text is defined %}
 
         {%- set attributes = attributes|default({})|merge({class: attributes.class|default([])|merge(['tag-list__title']) }) -%}
         {%- include 'atoms-heading' with {level: level|default(4)} -%}

--- a/source/_patterns/02-organisms/content-header/content-header.twig
+++ b/source/_patterns/02-organisms/content-header/content-header.twig
@@ -7,7 +7,7 @@
     {%- with categories|default({}) only -%}
       {%- block categories -%}
 
-        {%- if items|length -%}
+        {%- if items|default([])|length -%}
           {%- include 'molecules-tag-list' with {list: _context|merge({singleLine: true})} only -%}
         {%- endif -%}
 


### PR DESCRIPTION
By default the [`strict_variables` Twig option is `false`](https://twig.symfony.com/doc/2.x/api.html#environment-options) so undefined variables are treated as `null`. But if someone using it has it turned on, some patterns break. So, we should be defensive and have it turned on.