### PR TITLE
Add covert-link mixin

### DIFF
--- a/source/css/sass/mixins/_typography.scss
+++ b/source/css/sass/mixins/_typography.scss
@@ -3,6 +3,7 @@
 @import "../variables/color";
 @import "../variables/font";
 @import "spacing";
+@import "utilities";
 
 @mixin set-font-size-and-line-height($font-size, $block-size: $baselinegrid-space-small) {
   @include rem(font-size, $font-size);
@@ -110,14 +111,9 @@
   @include _label-typography($color-primary-normal);
 }
 
-@mixin hidden-link($hover-color: $color-primary-dark) {
-  color: inherit;
-  text-decoration: inherit;
-  all: inherit;
-
-  @supports (all: inherit) {
-    cursor: pointer;
-  }
+@mixin covert-link($hover-color: $color-primary-dark) {
+  @include inherit-all($ensure: color text-decoration);
+  cursor: pointer;
 
   &:hover {
     color: $hover-color;

--- a/source/css/sass/mixins/_typography.scss
+++ b/source/css/sass/mixins/_typography.scss
@@ -109,3 +109,17 @@
 @mixin label-tag-typography() {
   @include _label-typography($color-primary-normal);
 }
+
+@mixin hidden-link($hover-color: $color-primary-dark) {
+  color: inherit;
+  text-decoration: inherit;
+  all: inherit;
+
+  @supports (all: inherit) {
+    cursor: pointer;
+  }
+
+  &:hover {
+    color: $hover-color;
+  }
+}

--- a/source/css/sass/mixins/_utilities.scss
+++ b/source/css/sass/mixins/_utilities.scss
@@ -1,0 +1,7 @@
+@mixin inherit-all($ensure: ()) {
+  @each $property in $ensure {
+    #{$property}: inherit;
+  }
+
+  all: inherit;
+}

--- a/source/css/sass/patterns/molecules/tag-list.scss
+++ b/source/css/sass/patterns/molecules/tag-list.scss
@@ -43,5 +43,5 @@
 }
 
 .tag-list__link {
-  @include hidden-link();
+  @include covert-link();
 }

--- a/source/css/sass/patterns/molecules/tag-list.scss
+++ b/source/css/sass/patterns/molecules/tag-list.scss
@@ -43,10 +43,5 @@
 }
 
 .tag-list__link {
-  color: inherit;
-  text-decoration: inherit;
-
-  &:hover {
-    color: $color-primary-dark;
-  }
+  @include hidden-link();
 }

--- a/test/sass/mixins/utilities.spec.scss
+++ b/test/sass/mixins/utilities.spec.scss
@@ -1,0 +1,40 @@
+@import "../test";
+@import "../../../source/css/sass/mixins/utilities";
+
+@include describe("@mixin inherit-all") {
+
+  @include it("generates a simple 'inherit: all'") {
+
+    @include assert() {
+
+      @include output {
+        @include inherit-all();
+      }
+
+      @include expect {
+        all: inherit;
+      }
+
+    }
+
+  }
+
+  @include it("can ensure some properties are inheritied") {
+
+    @include assert() {
+
+      @include output {
+        @include inherit-all($ensure: color margin);
+      }
+
+      @include expect {
+        color: inherit;
+        margin: inherit;
+        all: inherit;
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
From https://github.com/libero/pattern-library/pull/62/files#r267413362.

I added `all: inherit`, which we hadn't been doing before.