### PR TITLE
Restart watchers on failures, and watch tests

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,14 +6,17 @@ services:
       context: .
       target: gulp
     command: bash -c "npx gulp assemble --environment=development --sass-lint=${LINT_SASS} && npx gulp watch --environment=development --sass-lint=${LINT_SASS}"
+    restart: on-failure
     volumes:
       - ./libero-config:/app/libero-config
       - ./source:/app/source
+      - ./test:/app/test
   watch-build:
     build:
       context: .
       target: build
     command: core/watch
+    restart: on-failure
     volumes:
       - public:/app/public
       - ./source:/app/source:ro


### PR DESCRIPTION
I've noticed race conditions in `watch-build` where inotify recognises a temporary file, then something tries to read it after it's deleted, causing a fatal error. This takes the simple option of just restarting the watchers if they fail.

Also mounts in the `test` directory, so changes to the tests are recognised.