### PR TITLE
Stop covert links appearing as blocks

### DIFF
--- a/source/css/sass/mixins/_typography.scss
+++ b/source/css/sass/mixins/_typography.scss
@@ -102,8 +102,10 @@
 }
 
 @mixin covert-link($hover-color: $color-primary-dark) {
-  @include inherit-all($ensure: color text-decoration);
-  cursor: pointer;
+  @include inherit-all($ensure: color text-decoration) {
+    cursor: pointer;
+    display: inline;
+  }
 
   &:hover {
     color: $hover-color;

--- a/source/css/sass/mixins/_utilities.scss
+++ b/source/css/sass/mixins/_utilities.scss
@@ -3,5 +3,8 @@
     #{$property}: inherit;
   }
 
-  all: inherit;
+  @supports (all: inherit) {
+    all: inherit;
+    @content;
+  }
 }

--- a/test/sass/mixins/utilities.spec.scss
+++ b/test/sass/mixins/utilities.spec.scss
@@ -12,7 +12,9 @@
       }
 
       @include expect {
-        all: inherit;
+        @supports (all: inherit) {
+          all: inherit;
+        }
       }
 
     }
@@ -30,7 +32,30 @@
       @include expect {
         color: inherit;
         margin: inherit;
-        all: inherit;
+        @supports (all: inherit) {
+          all: inherit;
+        }
+      }
+
+    }
+
+  }
+
+  @include it("can set other properties so they are not inherited") {
+
+    @include assert() {
+
+      @include output {
+        @include inherit-all() {
+          display: inline;
+        }
+      }
+
+      @include expect {
+        @supports (all: inherit) {
+          all: inherit;
+          display: inline;
+        }
       }
 
     }


### PR DESCRIPTION
`all: inherit` really does inherit all, so we need to exclude `display`.

Unfortunately there's no a way to 'inherit all except'. Makes me wonder if we shouldn't use it...