### PR TITLE
change baselinegrid start from medium to small

### DIFF
--- a/source/sass/patterns/organisms/content-header.scss
+++ b/source/sass/patterns/organisms/content-header.scss
@@ -8,7 +8,7 @@
 
 .content-header {
   text-align: center;
-  @include padding($baselinegrid-space-medium, block-start);
+  @include padding($baselinegrid-space-small, block-start);
   @include block-spacing($end: $baselinegrid-space-medium - $grid-divider_size);
   @include border(block-end);
 }


### PR DESCRIPTION
Changed the baselinegrid start to match the eLife Pattern Library version. The reason behind this is so the download icon will line up correctly with the tag list.

On the eLife Pattern Library there is padding on the tag list and none on the content header where as currently in Libero there is padding on the content header and none on the tag list.