### PR TITLE
Spacing shorthand fix

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,7 +4,8 @@
     "./export/css/sass/**/*",
     "./source/sass/fonts/**/*",
     "./source/sass/variables/**/*",
-    "./source/sass/vendor/**/*"
+    "./source/sass/vendor/**/*",
+    "./test/sass/**/*"
   ],
   "plugins": [
     "stylelint-use-logical"

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,8 +4,7 @@
     "./export/css/sass/**/*",
     "./source/sass/fonts/**/*",
     "./source/sass/variables/**/*",
-    "./source/sass/vendor/**/*",
-    "./test/sass/**/*"
+    "./source/sass/vendor/**/*"
   ],
   "plugins": [
     "stylelint-use-logical"

--- a/source/sass/mixins/_logical-properties.scss
+++ b/source/sass/mixins/_logical-properties.scss
@@ -197,6 +197,50 @@
     @include _maybe-rem($to-rem, _property-name($property-name, height), $arguments);
     #{_property-name($property-name, block-size)}: _maybe-rem($to-rem, $arguments);
 
+  } @else if $dimension == all {
+
+    @if length($property-name) > 1 {
+      @include _error("Expected a single property name");
+    } @else if not index(margin padding, $property-name) {
+      @include _error("Can't combine block and inline for '#{$property-name}'");
+    } @else {
+
+      @include _expect_at_most($arguments, 4, "More than four arguments supplied") {
+        $blockStart: nth($arguments, 1);
+        $blockEnd: if(length($arguments) >= 3, nth($arguments, 3), $blockStart);
+        $inlineEnd: if(length($arguments) >= 2, nth($arguments, 2), $blockEnd);
+        $inlineStart: if(length($arguments) == 4, nth($arguments, 4), $inlineEnd);
+
+        @if $blockStart == $blockEnd and $blockStart == $inlineStart and $blockStart == $inlineEnd {
+          @include _maybe-rem($to-rem, $property-name, $blockStart);
+        } @else if $blockStart == $blockEnd and $inlineStart == $inlineEnd {
+          @include _maybe-rem($to-rem, $property-name, $blockStart $inlineStart);
+        } @else if $inlineStart == $inlineEnd {
+          @include _maybe-rem($to-rem, $property-name, $blockStart $inlineEnd $blockEnd);
+        } @else {
+
+          @include _when-left-to-right() {
+            @include _maybe-rem($to-rem, $property-name, $blockStart $inlineEnd $blockEnd $inlineStart);
+          }
+
+          @include _when-right-to-left() {
+            @include _maybe-rem($to-rem, $property-name, $blockStart $inlineStart $blockEnd $inlineEnd);
+          }
+
+          @include _when-logical() {
+            @if $blockStart != $blockEnd {
+              #{_property-name($property-name, block-start)}: _maybe-rem($to-rem, $blockStart);
+              #{_property-name($property-name, block-end)}: _maybe-rem($to-rem, $blockEnd);
+            }
+            #{_property-name($property-name, inline-start)}: _maybe-rem($to-rem, $inlineStart);
+            #{_property-name($property-name, inline-end)}: _maybe-rem($to-rem, $inlineEnd);
+          }
+
+        }
+      }
+
+    }
+
   } @else if index((top, bottom, left, right, width, height), $dimension) {
     @include _error("'#{$dimension}' is a physical dimension, use its logical equivilant");
   } @else {

--- a/source/sass/mixins/_logical-properties.scss
+++ b/source/sass/mixins/_logical-properties.scss
@@ -197,6 +197,11 @@
     @include _maybe-rem($to-rem, _property-name($property-name, height), $arguments);
     #{_property-name($property-name, block-size)}: _maybe-rem($to-rem, $arguments);
 
+  } @else if $dimension == null and length($arguments) == 4 {
+    #{_property-name($property-name, inline)}: _maybe-rem($to-rem, (nth($arguments, 2) nth($arguments, 4)));
+    #{_property-name($property-name, block)}: _maybe-rem($to-rem, (nth($arguments, 1) nth($arguments, 3)));
+  } @else if $dimension == null and length($arguments) != 4 {
+    @include _error("Must provide 4 arguments if not supplying a dimension but found #{length($arguments)} arguments");
   } @else if index((top, bottom, left, right, width, height), $dimension) {
     @include _error("'#{$dimension}' is a physical dimension, use its logical equivilant");
   } @else {

--- a/source/sass/mixins/_logical-properties.scss
+++ b/source/sass/mixins/_logical-properties.scss
@@ -197,11 +197,6 @@
     @include _maybe-rem($to-rem, _property-name($property-name, height), $arguments);
     #{_property-name($property-name, block-size)}: _maybe-rem($to-rem, $arguments);
 
-  } @else if $dimension == null and length($arguments) == 4 {
-    #{_property-name($property-name, inline)}: _maybe-rem($to-rem, (nth($arguments, 2) nth($arguments, 4)));
-    #{_property-name($property-name, block)}: _maybe-rem($to-rem, (nth($arguments, 1) nth($arguments, 3)));
-  } @else if $dimension == null and length($arguments) != 4 {
-    @include _error("Must provide 4 arguments if not supplying a dimension but found #{length($arguments)} arguments");
   } @else if index((top, bottom, left, right, width, height), $dimension) {
     @include _error("'#{$dimension}' is a physical dimension, use its logical equivilant");
   } @else {

--- a/source/sass/mixins/_spacing.scss
+++ b/source/sass/mixins/_spacing.scss
@@ -30,7 +30,14 @@
   @if $dimension == "" {
 
     @include _expect_at_most($sizes, 4, "More than four sizes supplied when no dimension") {
-      @include rem($space-type, $sizes);
+      @if length($sizes) == 4 and nth($sizes, 1) == nth($sizes, 2) and nth($sizes, 2) == nth($sizes, 3) and nth($sizes, 3) == nth($sizes, 4) {
+        @include rem($space-type, nth($sizes, 1));
+      } @else {
+        @include rem($space-type, $sizes);
+        @if length($sizes) == 4 {
+          @include logical-property($space-type, null, $sizes);
+        }
+      }
     }
 
   } @else if $dimension == inline {

--- a/source/sass/mixins/_spacing.scss
+++ b/source/sass/mixins/_spacing.scss
@@ -30,13 +30,15 @@
   @if $dimension == "" {
 
     @include _expect_at_most($sizes, 4, "More than four sizes supplied when no dimension") {
-      @if length($sizes) == 4 and nth($sizes, 1) == nth($sizes, 2) and nth($sizes, 2) == nth($sizes, 3) and nth($sizes, 3) == nth($sizes, 4) {
-        @include rem($space-type, nth($sizes, 1));
+      @if length($sizes) == 4 {
+        @if nth($sizes, 1) == nth($sizes, 2) and nth($sizes, 2) == nth($sizes, 3) and nth($sizes, 3) == nth($sizes, 4) {
+          @include rem($space-type, nth($sizes, 1));
+        } @else {
+          @include logical-property($space-type, inline, nth($sizes, 4) nth($sizes, 2));
+          @include logical-property($space-type, block, nth($sizes, 1) nth($sizes, 3));
+        }
       } @else {
         @include rem($space-type, $sizes);
-        @if length($sizes) == 4 {
-          @include logical-property($space-type, null, $sizes);
-        }
       }
     }
 

--- a/source/sass/mixins/_spacing.scss
+++ b/source/sass/mixins/_spacing.scss
@@ -30,16 +30,7 @@
   @if $dimension == "" {
 
     @include _expect_at_most($sizes, 4, "More than four sizes supplied when no dimension") {
-      @if length($sizes) == 4 {
-        @if nth($sizes, 1) == nth($sizes, 2) and nth($sizes, 2) == nth($sizes, 3) and nth($sizes, 3) == nth($sizes, 4) {
-          @include rem($space-type, nth($sizes, 1));
-        } @else {
-          @include logical-property($space-type, inline, nth($sizes, 4) nth($sizes, 2));
-          @include logical-property($space-type, block, nth($sizes, 1) nth($sizes, 3));
-        }
-      } @else {
-        @include rem($space-type, $sizes);
-      }
+      @include logical-property($space-type, all, $sizes);
     }
 
   } @else if $dimension == inline {

--- a/test/sass/mixins/logical-properties.spec.scss
+++ b/test/sass/mixins/logical-properties.spec.scss
@@ -1,6 +1,8 @@
 @import "../test";
 @import "../../../source/sass/mixins/logical-properties";
 
+/* stylelint-disable csstools/use-logical  */
+
 @include describe("@mixin logical-property") {
 
   @include it("generates correct fallbacks for the dimension 'inline'") {

--- a/test/sass/mixins/logical-properties.spec.scss
+++ b/test/sass/mixins/logical-properties.spec.scss
@@ -619,6 +619,190 @@
 
   }
 
+  @include it("generates correct fallbacks for the dimension 'all'") {
+
+    @include assert() {
+
+      @include output {
+        @include logical-property(margin, all, 16px);
+      }
+
+      @include expect {
+        margin: 16px;
+        margin: 1rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include logical-property(margin, all, 16px 16px);
+      }
+
+      @include expect {
+        margin: 16px;
+        margin: 1rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include logical-property(margin, all, 16px 32px);
+      }
+
+      @include expect {
+        margin: 16px 32px;
+        margin: 1rem 2rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include logical-property(margin, all, 16px 16px 16px);
+      }
+
+      @include expect {
+        margin: 16px;
+        margin: 1rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include logical-property(margin, all, 16px 16px 32px);
+      }
+
+      @include expect {
+        margin: 16px 16px 32px;
+        margin: 1rem 1rem 2rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include logical-property(margin, all, 16px 16px 16px 16px);
+      }
+
+      @include expect {
+        margin: 16px;
+        margin: 1rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include logical-property(margin, all, 16px 16px 16px 32px);
+      }
+
+      @include expect {
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          margin: 16px 16px 16px 32px;
+          margin: 1rem 1rem 1rem 2rem;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          margin: 16px 32px 16px 16px;
+          margin: 1rem 2rem 1rem 1rem;
+        }
+        html[dir][dir] & {
+          margin-inline-start: 2rem;
+          margin-inline-end: 1rem;
+        }
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include logical-property(margin, all, 16px 32px 48px 64px);
+      }
+
+      @include expect {
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          margin: 16px 32px 48px 64px;
+          margin: 1rem 2rem 3rem 4rem;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          margin: 16px 64px 48px 32px;
+          margin: 1rem 4rem 3rem 2rem;
+        }
+        html[dir][dir] & {
+          margin-block-start: 1rem;
+          margin-block-end: 3rem;
+          margin-inline-start: 4rem;
+          margin-inline-end: 2rem;
+        }
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include logical-property(padding, all, 16px);
+      }
+
+      @include expect {
+        padding: 16px;
+        padding: 1rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include logical-property(margin, all, 16px, $to-rem: false);
+      }
+
+      @include expect {
+        margin: 16px;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include logical-property(margin, all, 16px 32px 48px 64px, $to-rem: false);
+      }
+
+      @include expect {
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          margin: 16px 32px 48px 64px;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          margin: 16px 64px 48px 32px;
+        }
+        html[dir][dir] & {
+          margin-block-start: 16px;
+          margin-block-end: 48px;
+          margin-inline-start: 64px;
+          margin-inline-end: 32px;
+        }
+      }
+
+    }
+
+  }
+
   @include it("errors when 3 property name parts are passed") {
 
     @include assert() {
@@ -657,6 +841,34 @@
 
       @include contains {
         _error: "Unknown dimension 'foo'";
+      }
+
+    }
+
+  }
+
+  @include it("errors when in the dimensions 'all' with an invalid property name") {
+
+    @include assert() {
+
+      @include output {
+        @include logical-property(border, all, 16px);
+      }
+
+      @include expect {
+        _error: "Can't combine block and inline for 'border'";
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include logical-property((margin padding), all, 16px);
+      }
+
+      @include expect {
+        _error: "Expected a single property name";
       }
 
     }

--- a/test/sass/mixins/spacing.spec.scss
+++ b/test/sass/mixins/spacing.spec.scss
@@ -345,7 +345,7 @@
           padding-block-end: 8rem;
           padding-inline-start: 16rem;
           padding-inline-end: 3rem;
-          }
+        }
       }
 
     }

--- a/test/sass/mixins/spacing.spec.scss
+++ b/test/sass/mixins/spacing.spec.scss
@@ -1,6 +1,8 @@
 @import "../test";
 @import "../../../source/sass/mixins/spacing";
 
+/* stylelint-disable csstools/use-logical  */
+
 @include describe("@mixin padding") {
 
   @include it("generates correct fallbacks with a single zero value and no dimension") {
@@ -306,7 +308,7 @@
         html[dir][dir] & {
           padding-inline-start: 16rem;
           padding-inline-end: 3rem;
-          }
+        }
         padding-top: 0;
         padding-bottom: 128px;
         padding-bottom: 8rem;

--- a/test/sass/mixins/spacing.spec.scss
+++ b/test/sass/mixins/spacing.spec.scss
@@ -68,6 +68,19 @@
     @include assert() {
 
       @include output {
+        @include padding(32px 32px);
+      }
+
+      @include expect {
+        padding: 32px;
+        padding: 2rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
         @include padding(32px 48px);
       }
 
@@ -106,6 +119,32 @@
   }
 
   @include it("generates correct fallbacks with three non-zero values and no dimension") {
+
+    @include assert() {
+
+      @include output {
+        @include padding(32px 32px 32px);
+      }
+
+      @include expect {
+        padding: 32px;
+        padding: 2rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include padding(32px 48px 32px);
+      }
+
+      @include expect {
+        padding: 32px 48px;
+        padding: 2rem 3rem;
+      }
+
+    }
 
     @include assert() {
 
@@ -275,7 +314,7 @@
       }
 
       @include expect {
-        padding: 0 0 0;
+        padding: 0;
       }
 
     }
@@ -293,27 +332,20 @@
       @include expect {
         html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
-          padding-left: 256px;
-          padding-left: 16rem;
-          padding-right: 48px;
-          padding-right: 3rem;
+          padding: 0 48px 128px 256px;
+          padding: 0 3rem 8rem 16rem;
         }
         html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
-          padding-right: 256px;
-          padding-right: 16rem;
-          padding-left: 48px;
-          padding-left: 3rem;
+          padding: 0 256px 128px 48px;
+          padding: 0 16rem 8rem 3rem;
         }
         html[dir][dir] & {
+          padding-block-start: 0;
+          padding-block-end: 8rem;
           padding-inline-start: 16rem;
           padding-inline-end: 3rem;
-        }
-        padding-top: 0;
-        padding-bottom: 128px;
-        padding-bottom: 8rem;
-        padding-block-start: 0;
-        padding-block-end: 8rem;
+          }
       }
 
     }
@@ -327,22 +359,18 @@
       @include expect {
         html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
-          padding-left: 16em;
-          padding-right: 3em;
+          padding: 0 3em 8em 16em;
         }
         html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
-          padding-right: 16em;
-          padding-left: 3em;
+          padding: 0 16em 8em 3em;
         }
         html[dir][dir] & {
+          padding-block-start: 0;
+          padding-block-end: 8em;
           padding-inline-start: 16em;
           padding-inline-end: 3em;
         }
-        padding-top: 0;
-        padding-bottom: 8em;
-        padding-block-start: 0;
-        padding-block-end: 8em;
       }
 
     }
@@ -356,27 +384,20 @@
       @include expect {
         html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
-          padding-left: 256px;
-          padding-left: 16rem;
-          padding-right: 48px;
-          padding-right: 3rem;
+          padding: 0 48px 128px 256px;
+          padding: 0 3rem 8rem 16rem;
         }
         html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
-          padding-right: 256px;
-          padding-right: 16rem;
-          padding-left: 48px;
-          padding-left: 3rem;
+          padding: 0 256px 128px 48px;
+          padding: 0 16rem 8rem 3rem;
         }
         html[dir][dir] & {
+          padding-block-start: 0;
+          padding-block-end: 8rem;
           padding-inline-start: 16rem;
           padding-inline-end: 3rem;
         }
-        padding-top: 0;
-        padding-bottom: 128px;
-        padding-bottom: 8rem;
-        padding-block-start: 0;
-        padding-block-end: 8rem;
       }
     }
 
@@ -1292,6 +1313,19 @@
     @include assert() {
 
       @include output {
+        @include margin(32px 32px);
+      }
+
+      @include expect {
+        margin: 32px;
+        margin: 2rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
         @include margin(32px 48px);
       }
 
@@ -1330,6 +1364,32 @@
   }
 
   @include it("generates correct fallbacks with three non-zero values and no dimension") {
+
+    @include assert() {
+
+      @include output {
+        @include margin(32px 32px 32px);
+      }
+
+      @include expect {
+        margin: 32px;
+        margin: 2rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include margin(32px 48px 32px);
+      }
+
+      @include expect {
+        margin: 32px 48px;
+        margin: 2rem 3rem;
+      }
+
+    }
 
     @include assert() {
 
@@ -1499,7 +1559,7 @@
       }
 
       @include expect {
-        margin: 0 0 0;
+        margin: 0;
       }
 
     }
@@ -1517,27 +1577,20 @@
       @include expect {
         html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
-          margin-left: 256px;
-          margin-left: 16rem;
-          margin-right: 48px;
-          margin-right: 3rem;
+          margin: 0 48px 128px 256px;
+          margin: 0 3rem 8rem 16rem;
         }
         html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
-          margin-right: 256px;
-          margin-right: 16rem;
-          margin-left: 48px;
-          margin-left: 3rem;
+          margin: 0 256px 128px 48px;
+          margin: 0 16rem 8rem 3rem;
         }
         html[dir][dir] & {
+          margin-block-start: 0;
+          margin-block-end: 8rem;
           margin-inline-start: 16rem;
           margin-inline-end: 3rem;
         }
-        margin-top: 0;
-        margin-bottom: 128px;
-        margin-bottom: 8rem;
-        margin-block-start: 0;
-        margin-block-end: 8rem;
       }
 
     }
@@ -1551,22 +1604,18 @@
       @include expect {
         html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
-          margin-left: 16em;
-          margin-right: 3em;
+          margin: 0 3em 8em 16em;
         }
         html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
-          margin-right: 16em;
-          margin-left: 3em;
+          margin: 0 16em 8em 3em;
         }
         html[dir][dir] & {
+          margin-block-start: 0;
+          margin-block-end: 8em;
           margin-inline-start: 16em;
           margin-inline-end: 3em;
         }
-        margin-top: 0;
-        margin-bottom: 8em;
-        margin-block-start: 0;
-        margin-block-end: 8em;
       }
 
     }
@@ -1580,27 +1629,20 @@
       @include expect {
         html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
-          margin-left: 256px;
-          margin-left: 16rem;
-          margin-right: 48px;
-          margin-right: 3rem;
+          margin: 0 48px 128px 256px;
+          margin: 0 3rem 8rem 16rem;
         }
         html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
-          margin-right: 256px;
-          margin-right: 16rem;
-          margin-left: 48px;
-          margin-left: 3rem;
+          margin: 0 256px 128px 48px;
+          margin: 0 16rem 8rem 3rem;
         }
         html[dir][dir] & {
+          margin-block-start: 0;
+          margin-block-end: 8rem;
           margin-inline-start: 16rem;
           margin-inline-end: 3rem;
         }
-        margin-top: 0;
-        margin-bottom: 128px;
-        margin-bottom: 8rem;
-        margin-block-start: 0;
-        margin-block-end: 8rem;
       }
     }
 

--- a/test/sass/mixins/spacing.spec.scss
+++ b/test/sass/mixins/spacing.spec.scss
@@ -291,6 +291,8 @@
       @include expect {
         padding: 0 48px 128px 256px;
         padding: 0 3rem 8rem 16rem;
+        padding-inline: 3rem 16rem;
+        padding-block: 0 8rem;
       }
 
     }
@@ -303,6 +305,8 @@
 
       @include expect {
         padding: 0 3em 8em 16em;
+        padding-inline: 3em 16em;
+        padding-block: 0 8em;
       }
 
     }
@@ -316,6 +320,8 @@
       @include expect {
         padding: 0 48px 128px 256px;
         padding: 0 3rem 8rem 16rem;
+        padding-inline: 3rem 16rem;
+        padding-block: 0 8rem;
       }
 
     }
@@ -327,7 +333,7 @@
       }
 
       @include expect {
-        padding: 0 0 0 0;
+        padding: 0;
       }
 
     }
@@ -1457,6 +1463,9 @@
       @include expect {
         margin: 0 48px 128px 256px;
         margin: 0 3rem 8rem 16rem;
+        margin-inline: 3rem 16rem;
+        margin-block: 0 8rem;
+
       }
 
     }
@@ -1469,6 +1478,8 @@
 
       @include expect {
         margin: 0 3em 8em 16em;
+        margin-inline: 3em 16em;
+        margin-block: 0 8em;
       }
 
     }
@@ -1482,6 +1493,8 @@
       @include expect {
         margin: 0 48px 128px 256px;
         margin: 0 3rem 8rem 16rem;
+        margin-inline: 3rem 16rem;
+        margin-block: 0 8rem;
       }
 
     }
@@ -1493,7 +1506,7 @@
       }
 
       @include expect {
-        margin: 0 0 0 0;
+        margin: 0;
       }
 
     }

--- a/test/sass/mixins/spacing.spec.scss
+++ b/test/sass/mixins/spacing.spec.scss
@@ -289,10 +289,29 @@
       }
 
       @include expect {
-        padding: 0 48px 128px 256px;
-        padding: 0 3rem 8rem 16rem;
-        padding-inline: 3rem 16rem;
-        padding-block: 0 8rem;
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          padding-left: 256px;
+          padding-left: 16rem;
+          padding-right: 48px;
+          padding-right: 3rem;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          padding-right: 256px;
+          padding-right: 16rem;
+          padding-left: 48px;
+          padding-left: 3rem;
+        }
+        html[dir][dir] & {
+          padding-inline-start: 16rem;
+          padding-inline-end: 3rem;
+          }
+        padding-top: 0;
+        padding-bottom: 128px;
+        padding-bottom: 8rem;
+        padding-block-start: 0;
+        padding-block-end: 8rem;
       }
 
     }
@@ -304,9 +323,24 @@
       }
 
       @include expect {
-        padding: 0 3em 8em 16em;
-        padding-inline: 3em 16em;
-        padding-block: 0 8em;
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          padding-left: 16em;
+          padding-right: 3em;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          padding-right: 16em;
+          padding-left: 3em;
+        }
+        html[dir][dir] & {
+          padding-inline-start: 16em;
+          padding-inline-end: 3em;
+        }
+        padding-top: 0;
+        padding-bottom: 8em;
+        padding-block-start: 0;
+        padding-block-end: 8em;
       }
 
     }
@@ -318,12 +352,30 @@
       }
 
       @include expect {
-        padding: 0 48px 128px 256px;
-        padding: 0 3rem 8rem 16rem;
-        padding-inline: 3rem 16rem;
-        padding-block: 0 8rem;
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          padding-left: 256px;
+          padding-left: 16rem;
+          padding-right: 48px;
+          padding-right: 3rem;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          padding-right: 256px;
+          padding-right: 16rem;
+          padding-left: 48px;
+          padding-left: 3rem;
+        }
+        html[dir][dir] & {
+          padding-inline-start: 16rem;
+          padding-inline-end: 3rem;
+        }
+        padding-top: 0;
+        padding-bottom: 128px;
+        padding-bottom: 8rem;
+        padding-block-start: 0;
+        padding-block-end: 8rem;
       }
-
     }
 
     @include assert() {
@@ -1461,11 +1513,29 @@
       }
 
       @include expect {
-        margin: 0 48px 128px 256px;
-        margin: 0 3rem 8rem 16rem;
-        margin-inline: 3rem 16rem;
-        margin-block: 0 8rem;
-
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          margin-left: 256px;
+          margin-left: 16rem;
+          margin-right: 48px;
+          margin-right: 3rem;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          margin-right: 256px;
+          margin-right: 16rem;
+          margin-left: 48px;
+          margin-left: 3rem;
+        }
+        html[dir][dir] & {
+          margin-inline-start: 16rem;
+          margin-inline-end: 3rem;
+        }
+        margin-top: 0;
+        margin-bottom: 128px;
+        margin-bottom: 8rem;
+        margin-block-start: 0;
+        margin-block-end: 8rem;
       }
 
     }
@@ -1477,9 +1547,24 @@
       }
 
       @include expect {
-        margin: 0 3em 8em 16em;
-        margin-inline: 3em 16em;
-        margin-block: 0 8em;
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          margin-left: 16em;
+          margin-right: 3em;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          margin-right: 16em;
+          margin-left: 3em;
+        }
+        html[dir][dir] & {
+          margin-inline-start: 16em;
+          margin-inline-end: 3em;
+        }
+        margin-top: 0;
+        margin-bottom: 8em;
+        margin-block-start: 0;
+        margin-block-end: 8em;
       }
 
     }
@@ -1491,12 +1576,30 @@
       }
 
       @include expect {
-        margin: 0 48px 128px 256px;
-        margin: 0 3rem 8rem 16rem;
-        margin-inline: 3rem 16rem;
-        margin-block: 0 8rem;
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          margin-left: 256px;
+          margin-left: 16rem;
+          margin-right: 48px;
+          margin-right: 3rem;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          margin-right: 256px;
+          margin-right: 16rem;
+          margin-left: 48px;
+          margin-left: 3rem;
+        }
+        html[dir][dir] & {
+          margin-inline-start: 16rem;
+          margin-inline-end: 3rem;
+        }
+        margin-top: 0;
+        margin-bottom: 128px;
+        margin-bottom: 8rem;
+        margin-block-start: 0;
+        margin-block-end: 8rem;
       }
-
     }
 
     @include assert() {


### PR DESCRIPTION
Addresses [#152](https://github.com/libero/libero/issues/152).

Additionally:
- compresses 4-zero `padding`/`margin` `0 0 0 0`, into the single value `0`
- ~no longer lints sass tests (lint rules for sass aren't appropriate for the form the tests take)~ Disable some stylelint rules for tests where that makes sense