### PR TITLE
Allow words to break

### DIFF
--- a/source/sass/base/_normalize.scss
+++ b/source/sass/base/_normalize.scss
@@ -24,6 +24,9 @@ body {
   background-color: $color-background;
   color: $color-text-normal;
   text-rendering: optimizeLegibility;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  hyphens: auto;
   @include body-typography();
 }
 


### PR DESCRIPTION
http://unstable.libero.pub/articles/9583516 currently side-scrolls on smaller devices due to a long word of text:

<img width="475" alt="Screenshot 2019-06-21 at 09 24 50" src="https://user-images.githubusercontent.com/1784740/59908943-7aa72600-9406-11e9-80eb-78889e8a649f.png">

This introduces word break _and_ hyphenation. There's probably going to be times when we need to turn hyphenation, at least, off.