### PR TITLE
Make inline list items inline

### DIFF
--- a/source/sass/patterns/molecules/inline-list.scss
+++ b/source/sass/patterns/molecules/inline-list.scss
@@ -10,7 +10,7 @@
 }
 
 .inline-list__item {
-  display: inline-block;
+  display: inline;
   @include list-separator();
 
   .inline-list--alternative-separators & {


### PR DESCRIPTION
Related to https://github.com/libero/pattern-library/pull/112, wrapping of author names/affiliations isn't great.

Before:
<img width="484" alt="Screenshot 2019-06-21 at 09 55 17" src="https://user-images.githubusercontent.com/1784740/59910927-ccea4600-940a-11e9-8378-08d2ea39b190.png">

After:
<img width="473" alt="Screenshot 2019-06-21 at 09 55 36" src="https://user-images.githubusercontent.com/1784740/59910948-d378bd80-940a-11e9-9c06-cb042b9d11d1.png">

I looked at applying it to Content Meta and Tag List too, but with less than ideal results. Since those are meant to be small(er) text items, I've left them.
