### PR TITLE
Stop reference DOIs being full-width

### DIFF
--- a/source/sass/patterns/molecules/reference.scss
+++ b/source/sass/patterns/molecules/reference.scss
@@ -1,4 +1,5 @@
 @import "../../mixins/scale";
+@import "../../mixins/sizes";
 @import "../../mixins/spacing";
 @import "../../mixins/typography";
 @import "../../settings/font";
@@ -24,7 +25,8 @@
 
 .reference__doi {
   @include covert-link() {
-    display: block;
+    display: table;
+    @include inline-size(auto);
     @include block-spacing($end: 0);
     @include set-font-size-and-line-height(scale(-3));
   }

--- a/source/sass/patterns/molecules/reference.scss
+++ b/source/sass/patterns/molecules/reference.scss
@@ -25,7 +25,7 @@
 
 .reference__doi {
   @include covert-link() {
-    display: table;
+    display: inline-block;
     @include inline-size(auto);
     @include block-spacing($end: 0);
     @include set-font-size-and-line-height(scale(-3));


### PR DESCRIPTION
Currently they're full-width:

<img width="724" alt="Screenshot 2019-08-05 at 14 48 54" src="https://user-images.githubusercontent.com/1784740/62469546-5faf2c00-b790-11e9-9325-7fd637850e1b.png">

so it's all a link.